### PR TITLE
Add non-gzipped links for short code snippets

### DIFF
--- a/src/hooks/utils/useListener.ts
+++ b/src/hooks/utils/useListener.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+
+type Listener = () => any;
+type Options = any;
+
+type AddListener = (string, Listener, Options?) => any;
+type RemoveListener = (string, Listener) => any;
+
+type ListenerTarget =
+  | { addEventListener: AddListener; removeEventListener: RemoveListener }
+  | { on: AddListener; off: RemoveListener };
+
+export default function useListener(
+  target: ListenerTarget,
+  event: string,
+  listener: Listener,
+  options: Options,
+) {
+  useEffect(() => {
+    if (!target) {
+      return;
+    }
+    const domTarget = 'addEventListener' in target;
+    if (domTarget) {
+      target.addEventListener(event, listener, options);
+    } else {
+      target.on(event, listener, options);
+    }
+    return () => {
+      if (domTarget) {
+        target.removeEventListener(event, listener);
+      } else {
+        target.off(event, listener);
+      }
+    };
+  }, [target, event, listener, options]);
+  return listener;
+}

--- a/src/services/embedLinkService.spec.ts
+++ b/src/services/embedLinkService.spec.ts
@@ -3,10 +3,18 @@ import { parseEmbedLink, getEmbedLink } from './embedLinkService';
 import initialCode from '../config/initialCode';
 
 describe('embedLinkService', () => {
-  it('parses a link', () => {
-    expect(parseEmbedLink('/motoko/g/Ftqc6mAnLA8fhVT6knkjrY')).toStrictEqual({
+  it('parses a text link', () => {
+    expect(parseEmbedLink('/motoko/t/8tkCLb2vFUV')).toStrictEqual({
       language: 'motoko',
       code: '// TEST\n',
+    });
+  });
+  it('parses a gzip link', () => {
+    expect(
+      parseEmbedLink('/motoko/g/RAiRxx8net2ByM3QCJ9XXhrjaGZEn7Uv9JsTH1Ln7'),
+    ).toStrictEqual({
+      language: 'motoko',
+      code: 'import Prim "mo:⛔";\n',
     });
   });
   it('parses an empty gzip payload', () => {
@@ -21,12 +29,20 @@ describe('embedLinkService', () => {
       code: `${initialCode.trim()}\n`,
     });
   });
-  it('generates a link', () => {
+  it('generates a text link', () => {
     expect(
       getEmbedLink({
         language: 'motoko',
         code: '// TEST',
       }),
-    ).toBe('http://localhost:3000/motoko/g/Ftqc6mAnLA8fhVT6knkjrY');
+    ).toBe('http://localhost:3000/motoko/t/8tkCLb2vFUV');
+  });
+  it('generates a gzip link', () => {
+    expect(
+      getEmbedLink({
+        language: 'motoko',
+        code: '// TEST\n'.repeat(20),
+      }),
+    ).toBe('http://localhost:3000/motoko/g/P5gNeDqSDZ68NgTNboVTayQJXz');
   });
 });

--- a/src/services/embedLinkService.ts
+++ b/src/services/embedLinkService.ts
@@ -4,7 +4,30 @@ import initialCode from '../config/initialCode';
 
 const EMBED_LINK_BASE = window.location.origin;
 
-const GZIP_FORMAT = 'g'; // TODO: refactor
+interface Format {
+  name: string;
+  symbol: string;
+  shouldClaim(string): boolean;
+  encode(string): Uint8Array;
+  decode(Uint8Array): string;
+}
+
+const formats: Format[] = [
+  {
+    name: 'text',
+    symbol: 't',
+    shouldClaim: () => false,
+    encode: (text) => new TextEncoder().encode(text),
+    decode: (data) => new TextDecoder().decode(data),
+  },
+  {
+    name: 'gzip',
+    symbol: 'g',
+    shouldClaim: (text) => text.length > 20,
+    encode: (text) => pako.deflate(text),
+    decode: (data) => pako.inflate(data, { to: 'string' }),
+  },
+];
 
 export interface EmbedData {
   language: string;
@@ -20,31 +43,41 @@ export function parseEmbedLink(path: string): EmbedData {
   if (path.startsWith('/')) {
     path = path.substring(1);
   }
-  const [language = 'motoko', format = '', payload = ''] = path.split('/');
-  if (!format) {
+  const [language = 'motoko', symbol = '', payload = ''] = path.split('/');
+  if (!symbol) {
     // return { language, code: initialCodeMap.get(language) || '' };
     return { language: 'motoko', code: preprocessCode(initialCode) };
-  } else if (format === GZIP_FORMAT) {
-    let code: string;
-    try {
-      const data = bs58.decode(payload);
-      code = pako.inflate(data, { to: 'string' }) || '';
-    } catch (err) {
-      console.error(err);
-      //   if (language === 'motoko') {
-      code = '// Unable to parse embed link';
-      //   }
+  } else if (!payload) {
+    return { language: 'motoko', code: '' };
+  } else {
+    const format = formats.find((format) => format.symbol === symbol);
+    if (format) {
+      let code: string;
+      try {
+        const data = bs58.decode(payload);
+        code = format.decode(data) || '';
+      } catch (err) {
+        console.error(err);
+        //   if (language === 'motoko') {
+        code = '// Unable to parse embed link';
+        //   }
+      }
+      return { language, code: preprocessCode(code) };
+    } else {
+      return {
+        language,
+        code: preprocessCode('// Unknown embed link format'),
+      };
     }
-    return { language, code: preprocessCode(code) };
   }
-  return {
-    language,
-    code: preprocessCode('// Unknown embed link format'),
-  };
 }
 
 export function getEmbedLink({ language, code }: EmbedData): string {
-  const format = GZIP_FORMAT;
-  const payload = bs58.encode(pako.deflate(preprocessCode(code)));
-  return `${EMBED_LINK_BASE}/${language}/${format}/${payload}`;
+  code = preprocessCode(code);
+
+  const format =
+    formats.find((format) => format.shouldClaim(code)) || formats[0];
+  const data = format.encode(code);
+  const payload = bs58.encode(data);
+  return `${EMBED_LINK_BASE}/${language}/${format.symbol}/${payload}`;
 }


### PR DESCRIPTION
URL scheme: `https://embed.smartcontracts.org/motoko/t/*`
Default embed link format for snippets with less than 20 characters.