### PR TITLE
Infer semicolons based on indentation

### DIFF
--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import '../utils/patchGlobal';
 import Editor from 'react-simple-code-editor';
 import hljs from 'highlight.js/lib/core';
-import 'highlight.js/styles/github.css';
+// import 'highlight.js/styles/github.css';
 import configureHighlightJS from '../config/configureHighlightJS';
 import isMobile from '../utils/isMobile';
 

--- a/src/components/Embed.jsx
+++ b/src/components/Embed.jsx
@@ -8,6 +8,7 @@ import { getEmbedLink, parseEmbedLink } from '../services/embedLinkService';
 import useChangedState from '../hooks/useChangedState';
 import classNames from 'classnames';
 import isMobile from '../utils/isMobile';
+import preprocessMotoko from '../utils/preprocessMotoko';
 
 const language = 'motoko'; // TODO: refactor
 
@@ -18,9 +19,13 @@ export default function Embed() {
 
   const output = useMemo(() => {
     try {
+      let result = preprocessMotoko(code || '');
+
+      console.log(result.code); ///
+
       setMessage('');
-      Motoko.saveFile('Main.mo', code || '');
-      return Motoko.run([], 'Main.mo');
+      Motoko.saveFile('__embed__.mo', result.code);
+      return Motoko.run([], '__embed__.mo');
     } catch (err) {
       console.error(err);
       return { stderr: err.message || String(err) };

--- a/src/config/configureHighlightJS.js
+++ b/src/config/configureHighlightJS.js
@@ -6,6 +6,8 @@ export function configureHighlightJS(hljs) {
   });
 }
 
+// TODO: use 'motoko/contrib/hljs'
+
 export default function register(hljs) {
   var string = {
     className: 'string',

--- a/src/styles/embed.scss
+++ b/src/styles/embed.scss
@@ -1,0 +1,2 @@
+@import 'hljs.scss';
+

--- a/src/styles/hljs.scss
+++ b/src/styles/hljs.scss
@@ -1,0 +1,116 @@
+// Derived from: https://github.com/highlightjs/highlight.js/blob/main/src/styles/github.css
+
+.hljs {
+  color: #24292e;
+  background: #ffffff;
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  /* prettylights-syntax-keyword */
+  color: #d73a49;
+}
+
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  /* prettylights-syntax-entity */
+  color: #6f42c1;
+}
+
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id {
+  /* prettylights-syntax-constant */
+  color: #005cc5;
+}
+
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  /* prettylights-syntax-string */
+  color: #0c407b;
+}
+
+.hljs-built_in,
+.hljs-symbol {
+  /* prettylights-syntax-variable */
+  color: #e36209;
+}
+
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  /* prettylights-syntax-comment */
+  color: #6a737d;
+}
+
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  /* prettylights-syntax-entity-tag */
+  color: #22863a;
+}
+
+.hljs-subst {
+  /* prettylights-syntax-storage-modifier-import */
+  color: #24292e;
+}
+
+.hljs-section {
+  /* prettylights-syntax-markup-heading */
+  color: #005cc5;
+  font-weight: bold;
+}
+
+.hljs-bullet {
+  /* prettylights-syntax-markup-list */
+  color: #735c0f;
+}
+
+.hljs-emphasis {
+  /* prettylights-syntax-markup-italic */
+  color: #24292e;
+  font-style: italic;
+}
+
+.hljs-strong {
+  /* prettylights-syntax-markup-bold */
+  color: #24292e;
+  font-weight: bold;
+}
+
+.hljs-addition {
+  /* prettylights-syntax-markup-inserted */
+  color: #22863a;
+  background-color: #f0fff4;
+}
+
+.hljs-deletion {
+  /* prettylights-syntax-markup-deleted */
+  color: #b31d28;
+  background-color: #ffeef0;
+}
+
+.hljs-char.escape_,
+.hljs-link,
+.hljs-params,
+.hljs-property,
+.hljs-punctuation,
+.hljs-tag {
+  /* purposely ignored */
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,5 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Nunito&display=swap');
 
+@import 'embed.scss';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/utils/preprocessMotoko.ts
+++ b/src/utils/preprocessMotoko.ts
@@ -1,0 +1,43 @@
+const TAB = '  ';
+
+export default function preprocessMotoko(code) {
+  code = code.replace(/\t/g, TAB);
+
+  const annotations = [];
+
+  // infer semicolons
+
+  let nextIndent = 0;
+  code = code
+    .split('\n')
+    .reverse()
+    .map((line: string) => {
+      const trimmedLine = line.trim();
+      if (!trimmedLine || trimmedLine.startsWith('//')) {
+        return line;
+      }
+
+      let indent = 0;
+      while (indent < line.length && line.charAt(indent) === ' ') {
+        indent++;
+      }
+
+      if (
+        indent === nextIndent &&
+        !trimmedLine.endsWith(';') &&
+        !(trimmedLine.startsWith('/*') && trimmedLine.endsWith('*/'))
+      ) {
+        line += ';';
+      }
+
+      nextIndent = indent;
+      return line;
+    })
+    .reverse()
+    .join('\n');
+
+  return {
+    annotations,
+    code,
+  };
+}


### PR DESCRIPTION
Expressions of the form
```motoko
a
b
```
rewrite as
```motoko
a;
b
```
while expressions of the form
```motoko
a
  b
```
remain unchanged. This causes semicolons to become optional in most situations. 