### PR TITLE
Autodetect base library package usage

### DIFF
--- a/src/components/Embed.jsx
+++ b/src/components/Embed.jsx
@@ -149,7 +149,11 @@ export default function Embed() {
           )}
           onClick={() => (autoRun ? setAutoRun(false) : updatePackages())}
         >
-          {autoRun ? <FaPause /> : <FaPlay className="translate-x-[2px]" />}
+          {autoRun ? (
+            <FaPause />
+          ) : (
+            <FaPlay className="translate-x-[2px] text-green-600" />
+          )}
         </Button>
       </div>
       <div

--- a/src/components/Embed.jsx
+++ b/src/components/Embed.jsx
@@ -39,7 +39,7 @@ export default function Embed() {
   }, [code, autoRun]);
 
   const packages = useMemo(() => {
-    return attributes
+    const packages = attributes
       .filter((a) => a.key === 'package' && a.value?.includes(' '))
       .map((a) =>
         a.value
@@ -48,7 +48,12 @@ export default function Embed() {
           .filter((s) => s),
       )
       .filter((kv) => kv.length === 2);
-  }, [attributes]);
+
+    if (code.includes('"mo:base/')) {
+      packages.unshift(['base', 'dfinity/motoko-base/master/src']); // TODO: keep this?
+    }
+    return packages;
+  }, [attributes, code]);
 
   // Package string for memoization
   const packageData = JSON.stringify(packages);


### PR DESCRIPTION
Makes it possible to use the Motoko base library without using an explicit package attribute. 