### PR TITLE
Adjust pixels per line count in oEmbed API

### DIFF
--- a/netlify/functions/oembed.js
+++ b/netlify/functions/oembed.js
@@ -23,7 +23,7 @@ exports.handler = async (event, context) => {
     if (match) {
       const [, lineCount] = match;
       // height = Math.min(120 + lineCount * 24, height);
-      height = Math.min(140 + lineCount * 26, height);
+      height = Math.min(140 + lineCount * 27, height);
     }
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
Adds an additional pixel for each line in embedded Medium articles. 