### PR TITLE
Fix floating buttons for code snippets with 1-2 lines

### DIFF
--- a/netlify/functions/oembed.js
+++ b/netlify/functions/oembed.js
@@ -23,7 +23,7 @@ exports.handler = async (event, context) => {
     if (match) {
       const [, lineCount] = match;
       // height = Math.min(120 + lineCount * 24, height);
-      height = Math.min(145 + lineCount * 27, height);
+      height = Math.min(140 + lineCount * 28, height);
     }
   } catch (err) {
     console.error(err);

--- a/src/components/Embed.jsx
+++ b/src/components/Embed.jsx
@@ -173,7 +173,7 @@ export default function Embed({ limitHeight }) {
       >
         <CodeEditor value={inputCode} onChange={handleChange} />
       </div>
-      <div className="flex-grow flex flex-col space-y-2 p-2 absolute right-0 bottom-[100px] text-sm sm:top-0 pointer-events-none [&>*]:pointer-events-auto z-10">
+      <div className="space-y-2 p-2 absolute right-0 bottom-[100px] text-sm sm:top-0 pointer-events-none [&>*]:pointer-events-auto z-10">
         <Button
           tooltip="Copy permalink"
           className={classNames(changed && 'emphasized')}


### PR DESCRIPTION
Fixes a "squashing" effect caused by the floating button container using flexbox rendering. 