### PR TITLE
Cache static assets

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,4 @@
+# Cache static assets for a week
+/assets/*
+  Cache-Control: public
+  Cache-Control: max-age=604800


### PR DESCRIPTION
Adds headers to cache static assets such as the JS file containing the 2MB+ Motoko interpreter.