### PR TITLE
Adjust redirect logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
       content="https://embed.smartcontracts.org/social.png"
     />
     <meta property="og:url" content="https://embed.smartcontracts.org" />
-    <script type="module" src="/src/redirect.ts"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import React, { StrictMode } from 'react';
 import ReactDom from 'react-dom';
 
 import App from './components/App';
+import './redirect';
 import './styles/index.scss';
 
 ReactDom.render(

--- a/src/redirect.ts
+++ b/src/redirect.ts
@@ -4,8 +4,8 @@ import isEmbedded from './utils/isEmbedded';
 if (
   !isEmbedded &&
   (window.location.hostname.endsWith('.icp0.io') ||
-    window.location.hostname.endsWith('.ic0.app') ||
-    window.location.hostname === 'embed.smartcontracts.org')
+    window.location.hostname.endsWith('.ic0.app'))
+  // || window.location.hostname === 'embed.smartcontracts.org'
 ) {
   window.location.hostname = 'embed.motoko.org';
 }


### PR DESCRIPTION
Only redirects from `icp0.io` and `ic0.app` with the intention of using an HTTP redirect for [embed.smartcontracts.org](https://embed.smartcontracts.org).