### PR TITLE
Add `/services` alias for `/api`

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,3 @@
 /api/* /.netlify/functions/:splat 200
+/services/* /.netlify/functions/:splat 200
 /motoko* /index.html 200


### PR DESCRIPTION
Groundwork for migrating the oEmbed API to an IC canister.