### PR TITLE
Experiment: deactivate Netlify functions

### DIFF
--- a/netlify/functions/oembed.js
+++ b/netlify/functions/oembed.js
@@ -6,54 +6,59 @@ const BASE_URLS = [
 ];
 
 exports.handler = async (event, context) => {
-  const query = event.queryStringParameters;
-  const url = decodeURIComponent(query.url || '');
-  if (
-    !url ||
-    BASE_URLS.every(
-      (baseUrl) =>
-        !url.startsWith(baseUrl) ||
-        url.startsWith(`${baseUrl}/api`) ||
-        url.includes('.', baseUrl.length),
-    )
-  ) {
-    return {
-      statusCode: 400,
-      body: 'Invalid embed link',
-    };
-  }
-  const format = query.format;
-  const defaultWidth = 800;
-  const width = +query.maxwidth || defaultWidth;
-  let height = +query.maxheight || 500;
-  try {
-    const match = /[?&]lines=([0-9]+)/.exec(url);
-    if (match) {
-      const [, lineCount] = match;
-      // height = Math.min(120 + lineCount * 24, height);
-      height = Math.min(145 + lineCount * 28, height);
-    }
-  } catch (err) {
-    console.error(err);
-  }
+  // const query = event.queryStringParameters;
+  // const url = decodeURIComponent(query.url || '');
+  // if (
+  //   !url ||
+  //   BASE_URLS.every(
+  //     (baseUrl) =>
+  //       !url.startsWith(baseUrl) ||
+  //       url.startsWith(`${baseUrl}/api`) ||
+  //       url.includes('.', baseUrl.length),
+  //   )
+  // ) {
+  //   return {
+  //     statusCode: 400,
+  //     body: 'Invalid embed link',
+  //   };
+  // }
+  // const format = query.format;
+  // const defaultWidth = 800;
+  // const width = +query.maxwidth || defaultWidth;
+  // let height = +query.maxheight || 500;
+  // try {
+  //   const match = /[?&]lines=([0-9]+)/.exec(url);
+  //   if (match) {
+  //     const [, lineCount] = match;
+  //     // height = Math.min(120 + lineCount * 24, height);
+  //     height = Math.min(145 + lineCount * 28, height);
+  //   }
+  // } catch (err) {
+  //   console.error(err);
+  // }
 
-  const result = {
-    version: '1.0',
-    provider_name: 'Embed Motoko',
-    provider_url: 'https://embed.motoko.org',
-    type: 'rich',
-    width,
-    height,
-    html: `<iframe src="${encodeXML(
-      url,
-    )}" width="${width}" height="${height}" style="border:0" />`,
-  };
+  // const result = {
+  //   version: '1.0',
+  //   provider_name: 'Embed Motoko',
+  //   provider_url: 'https://embed.motoko.org',
+  //   type: 'rich',
+  //   width,
+  //   height,
+  //   html: `<iframe src="${encodeXML(
+  //     url,
+  //   )}" width="${width}" height="${height}" style="border:0" />`,
+  // };
+  // return {
+  //   statusCode: 200,
+  //   body: format === 'xml' ? getXML(result) : JSON.stringify(result),
+  //   headers: {
+  //     'Content-Type': format === 'xml' ? 'text/xml' : 'application/json',
+  //   },
+  // };
+
   return {
-    statusCode: 200,
-    body: format === 'xml' ? getXML(result) : JSON.stringify(result),
-    headers: {
-      'Content-Type': format === 'xml' ? 'text/xml' : 'application/json',
-    },
+    statusCode: 400,
+    body: 'Maintenance in progress. Please check back soon.',
   };
 };
 

--- a/netlify/functions/onebox.js
+++ b/netlify/functions/onebox.js
@@ -7,54 +7,59 @@ const BASE_URLS = [
 ];
 
 exports.handler = async (event, context) => {
-  const query = event.queryStringParameters;
-  const url = decodeURIComponent(query.url || '');
-  if (
-    !url ||
-    BASE_URLS.every(
-      (baseUrl) =>
-        !url.startsWith(baseUrl) ||
-        url.startsWith(`${baseUrl}/api`) ||
-        url.includes('.', baseUrl.length),
-    )
-  ) {
-    return {
-      statusCode: 400,
-      body: 'Invalid embed link',
-    };
-  }
-  const format = query.format;
-  const defaultWidth = 695; // DFINITY Dev Forum iframe width
-  const width = +query.maxwidth || defaultWidth;
-  let height = +query.maxheight || 500;
-  try {
-    const match = /[?&]lines=([0-9]+)/.exec(url);
-    if (match) {
-      const [, lineCount] = match;
-      height = Math.min(120 + lineCount * 24, height);
-      // height = Math.min(140 + lineCount * 28, height);
-    }
-  } catch (err) {
-    console.error(err);
-  }
+  // const query = event.queryStringParameters;
+  // const url = decodeURIComponent(query.url || '');
+  // if (
+  //   !url ||
+  //   BASE_URLS.every(
+  //     (baseUrl) =>
+  //       !url.startsWith(baseUrl) ||
+  //       url.startsWith(`${baseUrl}/api`) ||
+  //       url.includes('.', baseUrl.length),
+  //   )
+  // ) {
+  //   return {
+  //     statusCode: 400,
+  //     body: 'Invalid embed link',
+  //   };
+  // }
+  // const format = query.format;
+  // const defaultWidth = 695; // DFINITY Dev Forum iframe width
+  // const width = +query.maxwidth || defaultWidth;
+  // let height = +query.maxheight || 500;
+  // try {
+  //   const match = /[?&]lines=([0-9]+)/.exec(url);
+  //   if (match) {
+  //     const [, lineCount] = match;
+  //     height = Math.min(120 + lineCount * 24, height);
+  //     // height = Math.min(140 + lineCount * 28, height);
+  //   }
+  // } catch (err) {
+  //   console.error(err);
+  // }
 
-  const result = {
-    version: '1.0',
-    provider_name: 'Embed Motoko',
-    provider_url: 'https://embed.motoko.org',
-    type: 'rich',
-    width,
-    height,
-    html: `<iframe src="${encodeXML(
-      url,
-    )}" width="${width}" height="${height}" style="border:0" />`,
-  };
+  // const result = {
+  //   version: '1.0',
+  //   provider_name: 'Embed Motoko',
+  //   provider_url: 'https://embed.motoko.org',
+  //   type: 'rich',
+  //   width,
+  //   height,
+  //   html: `<iframe src="${encodeXML(
+  //     url,
+  //   )}" width="${width}" height="${height}" style="border:0" />`,
+  // };
+  // return {
+  //   statusCode: 200,
+  //   body: format === 'xml' ? getXML(result) : JSON.stringify(result),
+  //   headers: {
+  //     'Content-Type': format === 'xml' ? 'text/xml' : 'application/json',
+  //   },
+  // };
+
   return {
-    statusCode: 200,
-    body: format === 'xml' ? getXML(result) : JSON.stringify(result),
-    headers: {
-      'Content-Type': format === 'xml' ? 'text/xml' : 'application/json',
-    },
+    statusCode: 400,
+    body: 'Maintenance in progress. Please check back soon.',
   };
 };
 


### PR DESCRIPTION
This PR deactivates the deprecated Embed.ly and Onebox API endpoints in production during a time with low traffic (in case either Embedly or Discourse have yet to roll out the change on their end). 